### PR TITLE
Sftp scanDirectory recognising files as directories

### DIFF
--- a/src/Ssh/Sftp.php
+++ b/src/Ssh/Sftp.php
@@ -281,7 +281,8 @@ class Sftp extends Subsystem
 
             $filename = sprintf('%s/%s', $directory, $result);
 
-            if (false === @scandir($this->getUrl($filename))) {
+            $url = $this->getUrl($filename);
+            if (false === @scandir($this->getUrl($filename)) || @is_file($url)) {
                 $files[] = $filename;
             } else {
                 $directories[] = $filename;


### PR DESCRIPTION
`scandir` returns an empty array instead of the expected `false` to detect if it's a file.
Added an additional `is_file` check which should keep backwards compatibility.